### PR TITLE
port to python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ generation).
 
 ## Requirements
 
-`ktransw` is written in Python 2, so naturally it needs a Python 2 install.
+`ktransw` is written in Python 3, so naturally it needs a Python 3 install.  'ktransw.cmd' calls python launcher "py -3", so make sure python launcher is installed with your python 3 distribution.
 
 The script itself doesn't do any translation, so a copy of `ktrans.exe` (and
 related libraries) is also needed.

--- a/ktransw.cmd
+++ b/ktransw.cmd
@@ -1,33 +1,17 @@
 @echo off
-
 REM
-
 REM Copyright (c) 2016, G.A. vd. Hoorn
-
 REM
-
 REM Licensed under the Apache License, Version 2.0 (the "License");
-
 REM you may not use this file except in compliance with the License.
-
 REM You may obtain a copy of the License at
-
 REM
-
 REM     http://www.apache.org/licenses/LICENSE-2.0
-
 REM
-
 REM Unless required by applicable law or agreed to in writing, software
-
 REM distributed under the License is distributed on an "AS IS" BASIS,
-
 REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-
 REM See the License for the specific language governing permissions and
-
 REM limitations under the License.
-
 REM
-
-py -3 "%~dp0\ktransw.py" %*
+python "%~dp0\ktransw.py" %*

--- a/ktransw.cmd
+++ b/ktransw.cmd
@@ -1,17 +1,33 @@
 @echo off
+
 REM
+
 REM Copyright (c) 2016, G.A. vd. Hoorn
+
 REM
+
 REM Licensed under the Apache License, Version 2.0 (the "License");
+
 REM you may not use this file except in compliance with the License.
+
 REM You may obtain a copy of the License at
+
 REM
+
 REM     http://www.apache.org/licenses/LICENSE-2.0
+
 REM
+
 REM Unless required by applicable law or agreed to in writing, software
+
 REM distributed under the License is distributed on an "AS IS" BASIS,
+
 REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
 REM See the License for the specific language governing permissions and
+
 REM limitations under the License.
+
 REM
-python "%~dp0\ktransw.py" %*
+
+py -3 "%~dp0\ktransw.py" %*

--- a/ktransw.py
+++ b/ktransw.py
@@ -126,7 +126,7 @@ def main():
             args.ktrans_args[i] = os.path.abspath(args.ktrans_args[i])
 
     logger.debug("Parsed args:")
-    for key, val in vars(args).iteritems():
+    for key, val in vars(args).items():
         if type(val) == list:
             logger.debug("  {0}:".format(key))
             for item in val:
@@ -243,7 +243,7 @@ def main():
                         hdr_path = os.path.join(hdr_dir, hdr_path)
                         logger.debug("Found {0} in '{1}'".format(hdr, hdr_dir))
 
-                    except ValueError as e:
+                    except (ValueError) as e:
                         if not args.ignore_missing_hdrs:
                             # we were not asked to ignore this, so exit with an error
                             sys.stderr.write("ktransw: fatal error: {0}: No such file or directory\n".format(hdr))
@@ -312,7 +312,9 @@ def main():
             # TODO: we loose stdout/stderr interleaving here
             # TODO: the error messages refer to lines in the temporary,
             # preprocessed KAREL source file, not the original one.
-            sys.stdout.write(pstdout.replace(dname, os.path.dirname(kl_file)) + '\n')
+            pstdout = pstdout.decode('utf-8')
+            ktrans_out = pstdout.replace(dname, os.path.dirname(kl_file)) + '\n'
+            sys.stdout.write(ktrans_out)
 
         sys.exit(ktrans_proc.returncode)
 
@@ -326,7 +328,7 @@ def get_includes_from_file(fname):
 GPP_OP_ENTER='1'
 GPP_OP_EXIT='2'
 def scan_for_inc_stmts(text):
-    matches = re.findall(r'^-- INCLUDE_MARKER (\d+):(\S+):(\d+|)', text, re.MULTILINE)
+    matches = re.findall(r'^-- INCLUDE_MARKER (\d+):(\S+):(\d+|)', text.decode('utf-8'), re.MULTILINE)
     incs = []
     for (line_nr, fpath, op) in matches:
         if (op == GPP_OP_ENTER) and (fpath not in incs):

--- a/ktransw.py
+++ b/ktransw.py
@@ -207,6 +207,9 @@ def main():
             # positive, while ktrans' are negative ..)
             sys.exit(gpp_proc.returncode)
 
+        #remove blank lines
+        remove_blank_lines(fname)
+          
 
         # pre-processing done
 
@@ -321,6 +324,15 @@ def get_includes_from_file(fname):
     with open(fname, 'rb') as fd:
         source = fd.read()
         return scan_for_inc_stmts(source)
+
+def remove_blank_lines(fname):
+    with open(fname, 'r+') as inf:
+      lines = inf.readlines()
+      lines = [line for line in lines if line.strip() != ""]
+          
+      inf.seek(0)
+      inf.write(''.join(lines))
+      inf.truncate()
 
 
 GPP_OP_ENTER='1'

--- a/ktransw.py
+++ b/ktransw.py
@@ -243,7 +243,7 @@ def main():
                         hdr_path = os.path.join(hdr_dir, hdr_path)
                         logger.debug("Found {0} in '{1}'".format(hdr, hdr_dir))
 
-                    except (ValueError) as e:
+                    except ValueError as e:
                         if not args.ignore_missing_hdrs:
                             # we were not asked to ignore this, so exit with an error
                             sys.stderr.write("ktransw: fatal error: {0}: No such file or directory\n".format(hdr))
@@ -312,9 +312,7 @@ def main():
             # TODO: we loose stdout/stderr interleaving here
             # TODO: the error messages refer to lines in the temporary,
             # preprocessed KAREL source file, not the original one.
-            pstdout = pstdout.decode('utf-8')
-            ktrans_out = pstdout.replace(dname, os.path.dirname(kl_file)) + '\n'
-            sys.stdout.write(ktrans_out)
+            sys.stdout.write(pstdout.decode('utf-8').replace(dname, os.path.dirname(kl_file)) + '\n')
 
         sys.exit(ktrans_proc.returncode)
 


### PR DESCRIPTION
With python finally dropping support for python2 next year it might be a good idea to patch for python3. Only potential issue is that newer version of python use the py launcher executable instead of calling python with 'python' or 'python3' so the .cmd file also needed to be updated, which will not work if python launcher is not installed.